### PR TITLE
Add kvm amd support

### DIFF
--- a/setup
+++ b/setup
@@ -114,6 +114,7 @@ then
 		else
 			sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="quiet"/GRUB_CMDLINE_LINUX_DEFAULT="quiet amd_iommu=on iommu=pt video=vesafb:off video=efifb:off"/g' /etc/default/grub
 		fi
+		echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
 	fi
 
 	if [ ${OSX_PLATFORM} == "INTEL" ]


### PR DESCRIPTION
When starting any machine on AMD processor after running this script it errors with following error 
```
TASK ERROR: KVM virtualisation configured, but not available. Either disable in VM configuration or enable in BIOS.
```

After adding this line install works as expected on AMD machines