### PR TITLE
fixed an error with the Ventura recovery image download

### DIFF
--- a/tools/macrecovery/recovery_urls.txt
+++ b/tools/macrecovery/recovery_urls.txt
@@ -35,4 +35,4 @@ python macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
 
 # Latest version
 # ie. Ventura (13)
-python ./macrecovery.py -b Mac-B4831CEBD52A0C4C -m 00000000000000000 download
+python macrecovery.py -b Mac-B4831CEBD52A0C4C -m 00000000000000000 download


### PR DESCRIPTION
The Ventura image could not be downloaded due to an error on line 38 of recovery_urls.txt which included a superfluous "./"