### PR TITLE
Sonoma recovery download fix (800M -> 1450M)

### DIFF
--- a/setup
+++ b/setup
@@ -1413,7 +1413,7 @@ do
 
 			if [ ! -e ${ISODIR}/recovery-sonoma.iso ]
 			then
-				fallocate -l 800M ${TMPDIR}/recovery-sonoma.iso > ${LOGFILE} 2>> ${LOGFILE}
+				fallocate -l 1450M ${TMPDIR}/recovery-sonoma.iso > ${LOGFILE} 2>> ${LOGFILE}
 				mkfs.msdos -F 32 ${TMPDIR}/recovery-sonoma.iso -n SONOMA >> ${LOGFILE} 2>> ${LOGFILE}
 				LOOPDEV=`losetup -f --show ${TMPDIR}/recovery-sonoma.iso 2>> ${LOGFILE}`
 				mkdir -p /mnt/APPLE >> ${LOGFILE} 2>> ${LOGFILE}


### PR DESCRIPTION
For Sonoma, 800M is not enough, the recovery iso is always broken.

With this fix - it is ok and can boot to recovery.