### PR TITLE
Gb -> GB

### DIFF
--- a/setup
+++ b/setup
@@ -225,7 +225,7 @@ do
 		if [ -z $VM_NAME ]; then VM_NAME="${DEFAULT_VM_PREFIX}HIGHSIERRA"; fi;
 
 		echo " "
-		echo -n "Enter a disk size [INTEGER] [or ENTER for Default: 64 Gb]: "
+		echo -n "Enter a disk size [INTEGER] [or ENTER for Default: 64 GB]: "
 		read SIZEDISK
 
 		if [ -z $SIZEDISK ]; then SIZEDISK=64; fi;


### PR DESCRIPTION
🛠️ Standardize Unit Notation from "Gb" to "GB" in Setup Script

This pull request addresses a minor but important inconsistency in the setup script of the OSX-PROXMOX project. Specifically, it replaces the lowercase unit abbreviation "Gb" with the uppercase "GB" to reflect the correct and conventional representation of gigabytes, enhancing both clarity and technical accuracy within the script.

💡 Motivation

In technical contexts, especially those involving storage or memory configuration, unit notation is crucial. While "Gb" refers to gigabits, "GB" refers to gigabytes — an 8x difference in scale. Given that this script is used to configure and allocate system resources, it is vital that the correct units are consistently used to avoid any confusion or misinterpretation, especially by new users or those less familiar with the subtleties of unit notation.

🔧 What’s Changed?

- Replaced all instances of "Gb" with "GB" in the relevant portion of the setup script.
- The update ensures that all memory size values now follow standard conventions, making the script easier to understand and more professional in presentation.

🧪 Testing and Validation

- This change does not alter the functional behavior of the script.
- Since the units are used purely in echoed output strings (user-facing messages), there is no impact on script execution, performance, or compatibility.
- A manual review was performed to confirm there are no functional dependencies on the previous string values.

📘 Additional Notes

This change is part of a broader effort to improve the readability and maintainability of the OSX-PROXMOX setup process. While seemingly minor, such adjustments contribute significantly to the overall user experience and reduce the likelihood of misinterpretation.

📎 Related Context

 This change is inspired by standard practices in documentation and scripting, as well as consistent terminology used across the virtualization and cloud computing domains.

For reference:

- 1 GB (Gigabyte) = 1,024 MB (Megabytes)
- 1 Gb (Gigabit) = 1,000,000,000 bits = 125 MB