### PR TITLE
fix media type flags

### DIFF
--- a/setup
+++ b/setup
@@ -332,8 +332,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -372,8 +372,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -522,8 +522,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -562,8 +562,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -712,8 +712,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			 --ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M > ${LOGFILE} 2>> ${LOGFILE}
+			 --ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -752,8 +752,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -902,8 +902,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -942,8 +942,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1092,8 +1092,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1132,8 +1132,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1282,8 +1282,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1322,8 +1322,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1472,8 +1472,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1512,8 +1512,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1662,8 +1662,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1702,8 +1702,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M \
-			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]

--- a/setup
+++ b/setup
@@ -332,8 +332,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -372,8 +372,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -522,8 +522,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -562,8 +562,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -712,8 +712,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			 --ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			 --ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -752,8 +752,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -902,8 +902,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -942,8 +942,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1092,8 +1092,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1132,8 +1132,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1282,8 +1282,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1322,8 +1322,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1472,8 +1472,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1512,8 +1512,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1662,8 +1662,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1702,8 +1702,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
-			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
+			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]

--- a/setup
+++ b/setup
@@ -332,8 +332,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -372,8 +372,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-highsierra.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -522,8 +522,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -562,8 +562,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--sata0 ${STORAGECRTVM}:${SIZEDISK},cache=none,ssd=1,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-mojave.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -712,8 +712,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			 --ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			 --ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -752,8 +752,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-catalina.iso,cache=unsafe,size=800M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -902,8 +902,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -942,8 +942,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-bigsur.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1092,8 +1092,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1132,8 +1132,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-monterey.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1282,8 +1282,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1322,8 +1322,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-ventura.iso,cache=unsafe,size=1024M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1472,8 +1472,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1512,8 +1512,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sonoma.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1662,8 +1662,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]
@@ -1702,8 +1702,8 @@ do
 			--vmgenid 1 \
 			--scsihw virtio-scsi-pci \
 			--virtio0 ${STORAGECRTVM}:${SIZEDISK},cache=none,discard=on \
-			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=disk \
-			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=disk > ${LOGFILE} 2>> ${LOGFILE}
+			--ide0 local:iso/opencore-osx-proxmox-vm.iso,cache=unsafe,size=80M,media=cdrom \
+			--ide2 local:iso/recovery-sequoia.iso,cache=unsafe,size=1450M,media=cdrom > ${LOGFILE} 2>> ${LOGFILE}
 
 			## Fix for QEMU 6.1 for PCI Passthrough
 			if [ `qemu-system-x86_64 --version | grep -e "6.1" -e "6.2" -e "7.1" -e "7.2" -e "8.0" -e "8.1" -e "9.0.2" | wc -l` -eq 1 ]

--- a/setup
+++ b/setup
@@ -1712,7 +1712,7 @@ do
 			fi
 
 		fi
-
+		sed -i 's/media=cdrom/media=disk/' /etc/pve/qemu-server/${VM_ID}.conf
 		echo "Virtual machine (${VM_NAME}) created successfully."
 		echo " "
 		echo "Access the Proxmox Web Panel to continue with the installation ..."


### PR DESCRIPTION
Fixes the error
```
400 Parameter verification failed.
ide0: explicit 'media=cdrom' is required for iso images
qm create <vmid> [OPTIONS]
``` 